### PR TITLE
Feature/week viewer recoil

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { RecoilRoot } from 'recoil';
 
 import { UserScreenNavigation } from './src/navigations';
 
 const App = () => {
-  return <UserScreenNavigation />;
+  return (
+    <RecoilRoot>
+      <UserScreenNavigation />
+    </RecoilRoot>
+  );
 };
 
 export default App;

--- a/src/components/DayViewer/DayViewer.styles.ts
+++ b/src/components/DayViewer/DayViewer.styles.ts
@@ -1,18 +1,27 @@
 import { StyleSheet } from 'react-native';
 
-export const styles = StyleSheet.create({
-  dayViewerContainer: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    margin: 17,
-  },
-  dayOfTheWeekTextWrapper: {
-    marginBottom: 5,
-    fontWeight: 'bold',
-    color: '#414141',
-  },
-  dayWrapper: {
-    fontWeight: 'bold',
-    color: '#414141',
-  },
-});
+export const styles = (isTargetDay: boolean) =>
+  StyleSheet.create({
+    dayViewerContainer: {
+      justifyContent: 'center',
+      alignItems: 'center',
+      margin: 12,
+    },
+    dayOfTheWeekText: {
+      marginBottom: 5,
+      fontWeight: 'bold',
+      color: '#414141',
+    },
+    dayTextrWrapper: {
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: 30,
+      height: 30,
+      backgroundColor: isTargetDay ? '#8BF996' : 'none',
+      borderRadius: 50,
+    },
+    dayText: {
+      fontWeight: 'bold',
+      color: '#414141',
+    },
+  });

--- a/src/components/DayViewer/DayViewer.styles.ts
+++ b/src/components/DayViewer/DayViewer.styles.ts
@@ -7,7 +7,12 @@ export const styles = StyleSheet.create({
     margin: 17,
   },
   dayOfTheWeekTextWrapper: {
-    color: '#414141',
     marginBottom: 5,
+    fontWeight: 'bold',
+    color: '#414141',
+  },
+  dayWrapper: {
+    fontWeight: 'bold',
+    color: '#414141',
   },
 });

--- a/src/components/DayViewer/DayViewer.types.ts
+++ b/src/components/DayViewer/DayViewer.types.ts
@@ -3,4 +3,5 @@ import { Week } from '../../types';
 export interface DayViewerProps {
   day: number;
   dayOfTheWeek: Week;
+  isTargetDay: boolean;
 }

--- a/src/components/DayViewer/index.tsx
+++ b/src/components/DayViewer/index.tsx
@@ -4,12 +4,14 @@ import { View, Text } from 'react-native';
 import { DayViewerProps } from './DayViewer.types';
 import { styles } from './DayViewer.styles';
 
-const DayViewer = ({ day, dayOfTheWeek }: DayViewerProps) => {
+const DayViewer = ({ day, dayOfTheWeek, isTargetDay }: DayViewerProps) => {
+  const style = styles(isTargetDay);
+
   return (
-    <View style={styles.dayViewerContainer}>
-      <Text style={styles.dayOfTheWeekTextWrapper}>{dayOfTheWeek}</Text>
-      <View>
-        <Text style={styles.dayWrapper}>{day}</Text>
+    <View style={style.dayViewerContainer}>
+      <Text style={style.dayOfTheWeekText}>{dayOfTheWeek}</Text>
+      <View style={style.dayTextrWrapper}>
+        <Text style={style.dayText}>{day}</Text>
       </View>
     </View>
   );

--- a/src/components/DayViewer/index.tsx
+++ b/src/components/DayViewer/index.tsx
@@ -9,7 +9,7 @@ const DayViewer = ({ day, dayOfTheWeek }: DayViewerProps) => {
     <View style={styles.dayViewerContainer}>
       <Text style={styles.dayOfTheWeekTextWrapper}>{dayOfTheWeek}</Text>
       <View>
-        <Text>{day}</Text>
+        <Text style={styles.dayWrapper}>{day}</Text>
       </View>
     </View>
   );

--- a/src/containers/WeekViewer/WeekViewer.styles.ts
+++ b/src/containers/WeekViewer/WeekViewer.styles.ts
@@ -6,6 +6,8 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
+    width: '100%',
     paddingTop: 50,
+    backgroundColor: '#ffffff',
   },
 });

--- a/src/containers/WeekViewer/index.tsx
+++ b/src/containers/WeekViewer/index.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import { View } from 'react-native';
+import { useRecoilValue } from 'recoil';
 
 import { DayViewer } from '../../components';
 
-import { getWeek } from '../../utils';
+import { habitDay } from '../../relay/atoms';
+
+import { getWeek, isSameDate } from '../../utils';
 import { Week } from '../../types';
 
 import { styles } from './WeekViewer.styles';
@@ -11,6 +14,8 @@ import { styles } from './WeekViewer.styles';
 const dayOfTheWeekList: Week[] = ['일', '월', '화', '수', '목', '금', '토'];
 
 const WeekViewer = () => {
+  const habitTargetDate = useRecoilValue(habitDay);
+
   const weak = getWeek();
 
   return (
@@ -18,8 +23,9 @@ const WeekViewer = () => {
       {dayOfTheWeekList.map(dayOfTheWeek => (
         <DayViewer
           key={dayOfTheWeek}
-          day={weak[dayOfTheWeek]}
+          day={weak[dayOfTheWeek].getDate()}
           dayOfTheWeek={dayOfTheWeek}
+          isTargetDay={isSameDate(habitTargetDate, weak[dayOfTheWeek])}
         />
       ))}
     </View>

--- a/src/relay/atoms/habitDay.ts
+++ b/src/relay/atoms/habitDay.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const habitDay = atom<Date>({
+  key: 'habitDayState',
+  default: new Date(),
+});

--- a/src/relay/atoms/index.ts
+++ b/src/relay/atoms/index.ts
@@ -1,0 +1,3 @@
+import { habitDay } from './habitDay';
+
+export { habitDay };

--- a/src/types/date.ts
+++ b/src/types/date.ts
@@ -1,5 +1,5 @@
 export type Week = '일' | '월' | '화' | '수' | '목' | '금' | '토';
 
 export type DateInfo = {
-  [dayOfTheWeek in Week]: number;
+  [dayOfTheWeek in Week]: Date;
 };

--- a/src/utils/getWeek.ts
+++ b/src/utils/getWeek.ts
@@ -14,13 +14,13 @@ const getWeek = (): DateInfo => {
   const threeDaysLater = getDateRelativeToToday(3);
 
   const dateInfo: DateInfo = {
-    일: threeDaysAgo.getDate(),
-    월: twoDaysAgo.getDate(),
-    화: yesterday.getDate(),
-    수: today.getDate(),
-    목: tomorrow.getDate(),
-    금: twoDaysLater.getDate(),
-    토: threeDaysLater.getDate(),
+    일: threeDaysAgo,
+    월: twoDaysAgo,
+    화: yesterday,
+    수: today,
+    목: tomorrow,
+    금: twoDaysLater,
+    토: threeDaysLater,
   };
 
   return dateInfo;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import getWeek from './getWeek';
+import isSameDate from './isSameDate';
 import getDateRelativeToToday from './getDateRelativeToToday';
 
-export { getWeek, getDateRelativeToToday };
+export { getWeek, isSameDate, getDateRelativeToToday };

--- a/src/utils/isSameDate.ts
+++ b/src/utils/isSameDate.ts
@@ -1,0 +1,9 @@
+const isSameDate = (firstDate: Date, secondDate: Date) => {
+  return (
+    firstDate.getFullYear() === secondDate.getFullYear() &&
+    firstDate.getMonth() === secondDate.getMonth() &&
+    firstDate.getDate() === secondDate.getDate()
+  );
+};
+
+export default isSameDate;


### PR DESCRIPTION
### 설명
---
Week viewer 에서 특정 일자의 habit 일자를 확인하기 위한 recoil atom 및 style 을 적용했습니다.

### Commit 내용
---
recoil 을 사용하기 위해 App 에 RecoilRoot provider 를 적용했습니다. 8909e15

DayViewer 에서 target habit day 를 표기하기 위해 style 에 parameter 를 전달할 수 있도록 함수로 변경,
DayViewer props 에 isTargetDay 를 추가했습니다. fe2f1df

habitDay atom 을 추가했습니다. 89b59db
위 state 는 target habit day 에 사용할 예정입니다.

DateInfo type 의 value 가 기존 `number` 에서 `Date` 로 변경했습니다.
기존 number 로 return 할 경우 target habit day 를 판별할 때
년, 월에 대한 구분이 안되는 문제가 있어 위와 같이 변경했습니다. 787d561

isSameDate util function 을 추가했습니다.
해당 function 은 두 Date 객체의 년, 월, 일을 비교하여 같은 일자인지 확인하는 용도입니다. 89ed523

habitDay atom state, 변경된 DayViewer 를 WeekViewer container 에 적용했습니다. bc497fb

### 시뮬레이션 asset
---

<img width="425" alt="스크린샷 2022-06-26 오후 9 44 38" src="https://user-images.githubusercontent.com/64253365/175814800-9fd4baf7-6dd8-4743-80b8-3f7c499f3bd4.png">


