### PR TITLE
fix: modify today set Date to new Date() setDate

### DIFF
--- a/src/utils/getWeek.ts
+++ b/src/utils/getWeek.ts
@@ -3,13 +3,13 @@ const getWeek = (): DateInfo => {
   const today = new Date();
   const first = today.getDate() - today.getDay() + 1;
 
-  const monday = new Date(today.setDate(first));
-  const tuesday = new Date(today.setDate(first + 1));
-  const wednesday = new Date(today.setDate(first + 2));
-  const thursday = new Date(today.setDate(first + 3));
-  const friday = new Date(today.setDate(first + 4));
-  const saturday = new Date(today.setDate(first + 6));
-  const sunday = new Date(today.setDate(first + 7));
+  const monday = new Date(new Date().setDate(first));
+  const tuesday = new Date(new Date().setDate(first + 1));
+  const wednesday = new Date(new Date().setDate(first + 2));
+  const thursday = new Date(new Date().setDate(first + 3));
+  const friday = new Date(new Date().setDate(first + 4));
+  const saturday = new Date(new Date().setDate(first + 6));
+  const sunday = new Date(new Date().setDate(first + 7));
 
   const dateInfo: DateInfo = {
     월: monday,


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : 기존 Week 캘린더에 오늘에 대한 highlight 문구가 보이지 않아 이를 해결하기 위한 FIx PR 입니다.

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

getWeek util function 에서 today Date 객체 기반으로 setDate 를 하는 방식에서
new Date() 로 별도의 Date 객체를 생성하여 적용하는 방식으로 변경했습니다. 5490838

## 🎥 ScreenShot or Video

### Before
<img width="438" alt="스크린샷 2022-07-01 오후 10 03 16" src="https://user-images.githubusercontent.com/64253365/176900000-7f156ecd-b082-4a0e-9672-5541a931ef0f.png">

### After
<img width="443" alt="스크린샷 2022-07-01 오후 10 03 56" src="https://user-images.githubusercontent.com/64253365/176900086-0e1fb881-dfa6-4505-8ad9-d31f86411e5b.png">


## Check List

today 대신 new Date 를 적용했을 떄 정상 동작하는 이유가 우선 궁금하고,
이에 대한 조사가 필요할 것 같습니다.

기존 today 기반 코드로 작성했을 때 Week Date 객체의 값입니다.
![스크린샷 2022-07-02 오전 9 36 39](https://user-images.githubusercontent.com/64253365/176980158-ed5acdac-895f-448a-b2b2-a4622ffdb01b.png)
2022년 7월 2일(토) 기준 확인을 했으며, 당초 계획과 전혀 다른 값이 산출되는 것을 확인할 수 있습니다.
'`setDate` method 를 사용할 경우, 대상 Date 객체를 변경하는 것이 아닐까 ' 라는 생각이 들었고 
 아래 코드로 간단하게 테스트를 진행해보았습니다.
 
 **setDate 를 사용하기 전**
 ```js
   const today = new Date(); // 2022년 07월 02일 (토) 기준
   console.log(today.getDay); // 6
 ```

**setDate 를 사용한 후**
```js
   const today = new Date(); // 2022년 07월 02일 (토) 기준
   console.log(today.getDay); // 6
```

```js
   const today = new Date(); // 2022년 07월 02일 (토) 기준
   today.setDate(3); 
   console.log(today.getDay); // 0 왜냐하면 3일은 일요일이며, 일요일의 getDay value 는 '0'이므로
```

위와 같이 today.setDate() 를 할 경우, 기존 today 객체가 변경되어 위와 같이 예상치 못한 결과를 도출하게 되었습니다.
현재 변경한 방식은 new Date() 로 각자 별도의 Date 객체에 setDate method 를 활용하여 값의 오염을 막을 수 있어,
버그를 해결할 수 있었습니다.

