### PR TITLE
Fix/subtitle font size

### DIFF
--- a/src/components/HabitPlusSubmitButton/HabitPlusSubmitButton.styles.ts
+++ b/src/components/HabitPlusSubmitButton/HabitPlusSubmitButton.styles.ts
@@ -11,7 +11,7 @@ export const styles = StyleSheet.create({
     backgroundColor: '#45E456',
   },
   submitButtonTitleText: {
-    fontSize: 14,
+    fontSize: 16,
     fontWeight: 'bold',
     color: '#414141',
   },

--- a/src/components/WhiteBoxWithSubTitle/WhiteBoxWithSubTitle.styles.ts
+++ b/src/components/WhiteBoxWithSubTitle/WhiteBoxWithSubTitle.styles.ts
@@ -8,7 +8,7 @@ export const styles = (minHeight?: number) =>
     },
     subTitleText: {
       marginLeft: 12,
-      fontSize: 12,
+      fontSize: 13,
       fontWeight: 'bold',
       color: '#414141',
     },


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 :  component 에서 Sub title 역할의 font size 를 기존 크기보다 up 시키는 PR 입니다.

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

submit button 의 텍스트 크기를 14 에서 16 으로 변경했습니다. bfe190b

setting box 의 sub title 텍스트 크기를 12 에서 13 으로 변경했습니다. a048d8f

## 🎥 ScreenShot or Video
**변경 전**
<img width="436" alt="스크린샷 2022-07-04 오후 5 08 22" src="https://user-images.githubusercontent.com/64253365/177110990-17f35ebb-6325-4597-8cc2-d3b7a85c1b83.png">

**변경 후**
<img width="433" alt="스크린샷 2022-07-04 오후 5 08 07" src="https://user-images.githubusercontent.com/64253365/177110939-928b4517-e63e-4c34-8cdd-ab9f26895362.png">


## Check List

기존 sub title 의 font size 는 콘텐츠와 같거나 조금 큰 사이즈로 적용되어 있어,
강조가 안되는 것 같다는 생각이 들어 현재 PR 을 통해 개선하고자 합니다.
