### PR TITLE
fix: modify socialContents, SocialProfileWithGrade style

### DIFF
--- a/src/components/SocialContents/SocialContents.styles.ts
+++ b/src/components/SocialContents/SocialContents.styles.ts
@@ -10,8 +10,9 @@ export const styles = StyleSheet.create({
   contentsHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
+    alignItems: 'flex-end',
     width: '100%',
+    marginBottom: 10,
   },
   contentsTitle: {
     fontSize: 12,

--- a/src/components/SocialProfileWIthGrade/SocialProfileWIthGrade.styles.ts
+++ b/src/components/SocialProfileWIthGrade/SocialProfileWIthGrade.styles.ts
@@ -5,7 +5,6 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    marginBottom: 10,
   },
   userInfoWrapper: {
     justifyContent: 'space-between',


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : Social Contents 의 Header 에 해당하는 스타일을 변경하는 작업 PR 입니다.

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

기존 ProfileWithGrade component 에서 불필요한 margin bottom style 을 제거한 후,
SocialContents 의 contentsHeader style 에 flex-end, marginBottom 을 적용하여,
Header 의 위치를 변경했습니다. 2d09533

## 🎥 ScreenShot or Video
**변경 전**
<img width="447" alt="스크린샷 2022-07-07 오후 1 42 56" src="https://user-images.githubusercontent.com/64253365/177692947-c098e796-3224-4619-842d-7635558fabba.png">


**변경 후**
<img width="439" alt="스크린샷 2022-07-07 오후 1 42 43" src="https://user-images.githubusercontent.com/64253365/177692921-289b59cf-28ec-4bdc-8290-e604b3889ad9.png">



## Check List
Profile, contents title 의 위치가 서로 같은 선상에 있지 않고, center 기준에 있어
이를 바로잡기 위해 위와 같이 변경했습니다.