### PR TITLE
feat: delete screenHeader to UserStatistics screen

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -294,7 +294,7 @@ PODS:
     - React-perflogger (= 0.69.1)
   - RNGestureHandler (2.5.0):
     - React-Core
-  - RNScreens (3.13.1):
+  - RNScreens (3.15.0):
     - React-Core
     - React-RCTImage
   - RNSVG (12.3.0):
@@ -426,7 +426,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 546a637adc797fa436dd51d1c63c580f820de31c
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
-  RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
+  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: ae07282b2ec9c90d7eb98251603bc3f82403d239
   RCTTypeSafety: a04dc1339af2e1da759ccd093bf11c310dce1ef6
   React: dbd201f781b180eab148aa961683943c72f67dcf
@@ -454,7 +454,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 27f468c5576eaf05ffb7a907528e44c75a3fcbae
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
   RNGestureHandler: bad495418bcbd3ab47017a38d93d290ebd406f50
-  RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
+  RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
 

--- a/src/screens/UserStatistics/UserStatistics.styles.ts
+++ b/src/screens/UserStatistics/UserStatistics.styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  growingTreeContainer: {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    paddingTop: 70,
+  },
+});

--- a/src/screens/UserStatistics/index.tsx
+++ b/src/screens/UserStatistics/index.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
+import { View } from 'react-native';
 
 import { ScreenContainer } from '../';
 
-import { ScreenHeader, Statistics } from '../../containers';
+import { Statistics } from '../../containers';
+
+import { styles } from './UserStatistics.styles';
 
 const UserStatistics = () => {
   return (
     <ScreenContainer>
-      <ScreenHeader headerTitle="나의 성공 지표" />
-      <Statistics />
+      <View style={styles.growingTreeContainer}>
+        <Statistics />
+      </View>
     </ScreenContainer>
   );
 };


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : UserStatistics Screen Header 를 삭제하는 작업 PR 입니다.

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

ScreenHeader 를 삭제하고, paddingTop 을 적용한 View 를 적용했습니다. e40655c

## 🎥 ScreenShot or Video
![스크린샷 2022-07-14 오후 9 40 50](https://user-images.githubusercontent.com/64253365/178984567-20d246a4-e07d-4e55-9377-2cbb15c94dfb.png)



## Check List
N/A