### PR TITLE
feat: add background style to HabitPlusButtons container

### DIFF
--- a/src/containers/HabitPlusButtons/HabitPlusButtons.styles.ts
+++ b/src/containers/HabitPlusButtons/HabitPlusButtons.styles.ts
@@ -2,6 +2,13 @@ import { StyleSheet } from 'react-native';
 
 export const styles = (isActiveOfPlus: boolean) =>
   StyleSheet.create({
+    habitPlusButtonsBackground: {
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      backgroundColor: isActiveOfPlus ? 'rgba(217, 217, 217, 0.6)' : 'none',
+      zIndex: isActiveOfPlus ? 0 : -1,
+    },
     habitPlusButtonsContainer: {
       alignItems: 'flex-end',
       position: 'absolute',

--- a/src/containers/HabitPlusButtons/index.tsx
+++ b/src/containers/HabitPlusButtons/index.tsx
@@ -72,47 +72,49 @@ const HabitPlusButtons = () => {
   }, [navigation]);
 
   return (
-    <View style={style.habitPlusButtonsContainer}>
-      <Animated.View
-        style={[
-          {
-            transform: [{ translateY: weekHabitTranslateY }],
-            opacity: weekHabitOpacity,
-          },
-        ]}>
-        <HabitPlusWithText
-          description="오늘 목표 추가"
-          backgroundColor="#AFA800"
-          onPress={() =>
-            navigation.navigate(ROUTE_PATH.HABIT_PLUS, {
-              habitPlusOption: 'day',
-            })
-          }
-        />
-      </Animated.View>
-      <Animated.View
-        style={[
-          {
-            transform: [{ translateY: todayHabitTranslateY }],
-            opacity: todayHabitOpacity,
-          },
-        ]}>
-        <HabitPlusWithText
-          description="주간 목표 추가"
-          backgroundColor="#EDE636"
-          onPress={() =>
-            navigation.navigate(ROUTE_PATH.HABIT_PLUS, {
-              habitPlusOption: 'week',
-            })
-          }
-        />
-      </Animated.View>
+    <View style={style.habitPlusButtonsBackground}>
+      <View style={style.habitPlusButtonsContainer}>
+        <Animated.View
+          style={[
+            {
+              transform: [{ translateY: weekHabitTranslateY }],
+              opacity: weekHabitOpacity,
+            },
+          ]}>
+          <HabitPlusWithText
+            description="오늘 목표 추가"
+            backgroundColor="#AFA800"
+            onPress={() =>
+              navigation.navigate(ROUTE_PATH.HABIT_PLUS, {
+                habitPlusOption: 'day',
+              })
+            }
+          />
+        </Animated.View>
+        <Animated.View
+          style={[
+            {
+              transform: [{ translateY: todayHabitTranslateY }],
+              opacity: todayHabitOpacity,
+            },
+          ]}>
+          <HabitPlusWithText
+            description="주간 목표 추가"
+            backgroundColor="#EDE636"
+            onPress={() =>
+              navigation.navigate(ROUTE_PATH.HABIT_PLUS, {
+                habitPlusOption: 'week',
+              })
+            }
+          />
+        </Animated.View>
 
-      <View style={style.habitPlusButton}>
-        <HabitPlus
-          backgroundColor="#FCF664"
-          onPress={handleHabitPlusButtonClick}
-        />
+        <View style={style.habitPlusButton}>
+          <HabitPlus
+            backgroundColor="#FCF664"
+            onPress={handleHabitPlusButtonClick}
+          />
+        </View>
       </View>
     </View>
   );


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 :  Habit Plus button 을 클릭했을 때 background 레이어가 하나 추가되어, 다른 기능을 사용하지 못하도록
             Protect 하는 방식을 적용한 PR 입니다.

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

HabitPlusButtons container 의 최상위 View 를 추가 후 button 활성화 여부에 따라 background color 가 깔린 후,
하단 레이어의 Habit Item, 요일 Click 기능을 사용하지 못하도록 스타일을 추가했습니다. 8f6a266

## 🎥 ScreenShot or Video

https://user-images.githubusercontent.com/64253365/179388242-0473f6a2-3c01-43c3-b307-79089b63a8c1.mov





## Check List

N/A