### PR TITLE
feat: add onPressCompleteIcon prop, TouchableOpacity to HabitItem

### DIFF
--- a/src/components/HabitItem/HabitItem.types.ts
+++ b/src/components/HabitItem/HabitItem.types.ts
@@ -2,4 +2,5 @@ export interface HabitItemProps {
   title: string;
   isComplete: boolean;
   onPress: () => void;
+  onPressCompleteIcon: () => void;
 }

--- a/src/components/HabitItem/index.tsx
+++ b/src/components/HabitItem/index.tsx
@@ -6,7 +6,12 @@ import { WateringCan } from '../../assets';
 import { HabitItemProps } from './HabitItem.types';
 import { styles } from './HabitItem.styles';
 
-const HabitItem = ({ title, isComplete, onPress }: HabitItemProps) => {
+const HabitItem = ({
+  title,
+  isComplete,
+  onPress,
+  onPressCompleteIcon,
+}: HabitItemProps) => {
   const style = styles(isComplete);
 
   return (
@@ -15,9 +20,11 @@ const HabitItem = ({ title, isComplete, onPress }: HabitItemProps) => {
         <View style={style.habitItemIcon} />
         <Text style={style.habitItemTitle}>{title}</Text>
       </View>
-      <View style={style.habitItemWateringCanIcon}>
+      <TouchableOpacity
+        style={style.habitItemWateringCanIcon}
+        onPress={onPressCompleteIcon}>
         <WateringCan fill="#000000" width={25} height={25} />
-      </View>
+      </TouchableOpacity>
     </TouchableOpacity>
   );
 };

--- a/src/containers/HabitList/index.tsx
+++ b/src/containers/HabitList/index.tsx
@@ -34,6 +34,7 @@ const HabitList = () => {
             {...habitItemInfo}
             key={habitItemInfo.title}
             onPress={() => handleHabitItemClick(habitItemInfo)}
+            onPressCompleteIcon={() => console.log('complete button click')}
           />
         ))
       )}


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적: HabitItem component Icon button event 추가 및 적용했습니다. 

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

HabitItem component 에서 complete icon 에 click 이벤트를 적용했습니다. ba5df32

## 🎥  ScreenShot or Video

https://user-images.githubusercontent.com/64253365/179529949-0acd079a-c58f-4d6b-913c-9bd31f1b2f76.mov



## Check List

N/A