### PR TITLE
refactor: modify useEffect to useFocusEffect in HabitPlusButtons

### DIFF
--- a/src/containers/HabitPlusButtons/index.tsx
+++ b/src/containers/HabitPlusButtons/index.tsx
@@ -1,6 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { View, Animated } from 'react-native';
-import { useNavigation, NavigationProp } from '@react-navigation/native';
+import {
+  useFocusEffect,
+  useNavigation,
+  NavigationProp,
+} from '@react-navigation/native';
 
 import { HabitPlus, HabitPlusWithText } from '../../components';
 
@@ -67,9 +71,11 @@ const HabitPlusButtons = () => {
     setIsActiveOfPlus(prevState => !prevState);
   };
 
-  useEffect(() => {
-    return navigation.addListener('focus', () => setIsActiveOfPlus(false));
-  }, [navigation]);
+  useFocusEffect(
+    useCallback(() => {
+      setIsActiveOfPlus(false);
+    }, []),
+  );
 
   return (
     <View style={style.habitPlusButtonsBackground}>


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적: 기존 useEffect 내에서 navigation 의 addListener 의 focus 를 도입하는 방식에서 useFocusEffect 를 사용한 방식으로 변겨앻ㅆ습니다.

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

useEffect 를 useFocusEffect 로 변경 f6caf3b

## 🎥  ScreenShot or Video

N/A

## Check List

N/A