### PR TITLE
Refactor/week viewer util

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
     "@react-navigation/stack": "^6.2.1",
+    "date-fns": "^2.29.1",
     "react": "18.0.0",
     "react-native": "0.69.1",
     "react-native-gesture-handler": "^2.5.0",

--- a/src/containers/WeekViewer/index.tsx
+++ b/src/containers/WeekViewer/index.tsx
@@ -6,7 +6,7 @@ import { DayViewer, YearAndMonth } from '../../components';
 
 import { habitDay } from '../../recoil/atoms';
 
-import { getWeek, isSameDate } from '../../utils';
+import { isSameDate, getWeek } from '../../utils';
 import { DAY_OF_THE_WEEK_LIST } from '../../constants/day';
 
 import { styles } from './WeekViewer.styles';
@@ -14,22 +14,26 @@ import { styles } from './WeekViewer.styles';
 const WeekViewer = () => {
   const [habitTargetDate, setHabitTargetDate] = useRecoilState(habitDay);
 
-  const weak = getWeek();
+  const week = getWeek(new Date());
 
   return (
     <View style={styles.WeekViewerContainer}>
       <View style={styles.WeekViewerChildrenContainer}>
         <YearAndMonth day={habitTargetDate} />
         <View style={styles.DayViewerWrapper}>
-          {DAY_OF_THE_WEEK_LIST.map(dayOfTheWeek => (
-            <DayViewer
-              key={dayOfTheWeek}
-              day={weak[dayOfTheWeek].getDate()}
-              dayOfTheWeek={dayOfTheWeek}
-              isTargetDay={isSameDate(habitTargetDate, weak[dayOfTheWeek])}
-              onPress={() => setHabitTargetDate(weak[dayOfTheWeek])}
-            />
-          ))}
+          {week.map((dayOfTheWeek, i) => {
+            const dayOfWeek = DAY_OF_THE_WEEK_LIST[i];
+
+            return (
+              <DayViewer
+                key={dayOfWeek}
+                day={dayOfTheWeek.getDate()}
+                dayOfTheWeek={DAY_OF_THE_WEEK_LIST[i]}
+                isTargetDay={isSameDate(habitTargetDate, dayOfTheWeek)}
+                onPress={() => setHabitTargetDate(dayOfTheWeek)}
+              />
+            );
+          })}
         </View>
       </View>
     </View>

--- a/src/mocks/habitList.ts
+++ b/src/mocks/habitList.ts
@@ -1,85 +1,85 @@
 import { HabitItem } from '../types';
 import { getWeek } from '../utils';
 
-const week = getWeek();
+const week = getWeek(new Date());
 
 export const habitList: { [date: string]: HabitItem[] } = {
-  [week['월'].getDate()]: [
+  [week[0].getDate()]: [
     {
-      date: week['월'],
+      date: week[0],
       isPrivate: false,
       isComplete: false,
       description: '',
       title: '월요일 평화롭게 보내기',
     },
     {
-      date: week['월'],
+      date: week[0],
       isPrivate: false,
       isComplete: false,
       description: '',
       title: '교보 문고 가서 개발 책 사기',
     },
   ],
-  [week['화'].getDate()]: [
+  [week[1].getDate()]: [
     {
-      date: week['화'],
+      date: week[1],
       isPrivate: false,
       isComplete: false,
       description: '',
       title: '병원 가서 허리 치료 받기',
     },
   ],
-  [week['수'].getDate()]: [],
-  [week['목'].getDate()]: [
+  [week[2].getDate()]: [],
+  [week[3].getDate()]: [
     {
-      date: week['목'],
+      date: week[3],
       isPrivate: true,
       isComplete: true,
       description: '',
       title: '아침에 물을 마시자!',
     },
     {
-      date: week['목'],
+      date: week[3],
       isPrivate: false,
       isComplete: false,
       description: '',
       title: 'TODO 리스트 작성',
     },
     {
-      date: week['목'],
+      date: week[3],
       isPrivate: false,
       isComplete: true,
       description: '',
       title: '점심에 샐러드를 먹자!',
     },
   ],
-  [week['금'].getDate()]: [
+  [week[4].getDate()]: [
     {
-      date: week['금'],
+      date: week[4],
       isPrivate: true,
       isComplete: true,
       description: '',
       title: '잠을 잘 자자',
     },
     {
-      date: week['금'],
+      date: week[4],
       isPrivate: true,
       isComplete: true,
       description: '',
       title: '고구마 맛탕 해먹기',
     },
     {
-      date: week['금'],
+      date: week[4],
       isPrivate: false,
       isComplete: false,
       description: '',
       title: '걷기 운동 30분 채우기',
     },
   ],
-  [week['토'].getDate()]: [],
-  [week['일'].getDate()]: [
+  [week[5].getDate()]: [],
+  [week[6].getDate()]: [
     {
-      date: week['일'],
+      date: week[6],
       isPrivate: false,
       isComplete: true,
       description: '',

--- a/src/utils/getWeek.ts
+++ b/src/utils/getWeek.ts
@@ -1,26 +1,14 @@
-import { DateInfo } from '../types';
+import { startOfWeek } from 'date-fns';
 
-const getWeek = (): DateInfo => {
-  const today = new Date();
-  const first = today.getDate() - today.getDay() + 1;
+import { DAY_OF_THE_WEEK_LIST } from '../constants/day';
 
-  const monday = new Date(new Date().setDate(first));
-  const tuesday = new Date(new Date().setDate(first + 1));
-  const wednesday = new Date(new Date().setDate(first + 2));
-  const thursday = new Date(new Date().setDate(first + 3));
-  const friday = new Date(new Date().setDate(first + 4));
-  const saturday = new Date(new Date().setDate(first + 5));
-  const sunday = new Date(new Date().setDate(first + 6));
+type DayIndex = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-  const dateInfo: DateInfo = {
-    월: monday,
-    화: tuesday,
-    수: wednesday,
-    목: thursday,
-    금: friday,
-    토: saturday,
-    일: sunday,
-  };
+const getWeek = (date: Date) => {
+  const dateInfo = DAY_OF_THE_WEEK_LIST.map((day, i) => {
+    const currentDayIndex = (day === '일' ? 0 : i + 1) as DayIndex;
+    return startOfWeek(date, { weekStartsOn: currentDayIndex });
+  });
 
   return dateInfo;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,6 +2736,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.1.tgz#9667c2615525e552b5135a3116b95b1961456e60"
+  integrity sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==
+
 dayjs@^1.8.15:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.3.tgz#4754eb694a624057b9ad2224b67b15d552589258"


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적: date-fns 를 통해 week 구하는 util function 을 개선하기 위한 PR 입니다.

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

기존 getWeek util function 은 일주일을 구할 수 있는 로직만을 적용했으나,
추후 week 를 슬라이드 할 때 다음주 혹은 저번주로 이동할 수 있는 기능 및 각종 캘린더 기능을 제공해야하기에
date-fns package 를 적용했습니다.  1ccdacd

월요일부터 일요일까지의 Date 를 객체로 던져주는 방식 대신 `월 ~ 일`까지의 Date 를 배열로 던져주는 방식으로
변경했습니다. 이전에는 객체로 던져주는 문제로 인해 상수값 DAY_OF_THE_WEEK_LIST 를 순회하는
다소 어색한 방법을 사용했기에 getWeek() 로 얻은 week 배열을 순회하여 DayViewer 를 return 하는 방식으로
수정했습니다. 0bf3e35


## 🎥  ScreenShot or Video

N/A

## Check List

N/A