### PR TITLE
Feature/week viewer default date

### DIFF
--- a/src/mocks/habitList.ts
+++ b/src/mocks/habitList.ts
@@ -87,3 +87,87 @@ export const habitList: { [date: string]: HabitItem[] } = {
     },
   ],
 };
+
+export const mockHabitItemList: HabitItem[][] = [
+  [
+    {
+      date: week[0],
+      isPrivate: false,
+      isComplete: false,
+      description: '',
+      title: '월요일 평화롭게 보내기',
+    },
+    {
+      date: week[0],
+      isPrivate: false,
+      isComplete: false,
+      description: '',
+      title: '교보 문고 가서 개발 책 사기',
+    },
+  ],
+  [
+    {
+      date: week[1],
+      isPrivate: false,
+      isComplete: false,
+      description: '',
+      title: '병원 가서 허리 치료 받기',
+    },
+  ],
+  [
+    {
+      date: week[3],
+      isPrivate: true,
+      isComplete: true,
+      description: '',
+      title: '아침에 물을 마시자!',
+    },
+    {
+      date: week[3],
+      isPrivate: false,
+      isComplete: false,
+      description: '',
+      title: 'TODO 리스트 작성',
+    },
+    {
+      date: week[3],
+      isPrivate: false,
+      isComplete: true,
+      description: '',
+      title: '점심에 샐러드를 먹자!',
+    },
+  ],
+  [
+    {
+      date: week[4],
+      isPrivate: true,
+      isComplete: true,
+      description: '',
+      title: '잠을 잘 자자',
+    },
+    {
+      date: week[4],
+      isPrivate: true,
+      isComplete: true,
+      description: '',
+      title: '고구마 맛탕 해먹기',
+    },
+    {
+      date: week[4],
+      isPrivate: false,
+      isComplete: false,
+      description: '',
+      title: '걷기 운동 30분 채우기',
+    },
+  ],
+  [],
+  [
+    {
+      date: week[6],
+      isPrivate: false,
+      isComplete: true,
+      description: '',
+      title: '나의 일요일 만끽하기',
+    },
+  ],
+];

--- a/src/recoil/selectors/filteredHabitList.ts
+++ b/src/recoil/selectors/filteredHabitList.ts
@@ -2,7 +2,14 @@ import { selector } from 'recoil';
 
 import { habitDay } from '../atoms';
 
-import { habitList as mockHabitList } from '../../mocks/habitList';
+import {
+  habitList as mockHabitList,
+  mockHabitItemList,
+} from '../../mocks/habitList';
+
+function getRandomInt(max: number) {
+  return Math.floor(Math.random() * max);
+}
 
 export const filteredHabitListState = selector({
   key: 'filteredHabitListState',
@@ -10,7 +17,8 @@ export const filteredHabitListState = selector({
     const today = get(habitDay);
     const date = today.getDate();
 
-    const filteredHabitList = mockHabitList[date];
+    const filteredHabitList =
+      mockHabitList[date] ?? mockHabitItemList[getRandomInt(6)];
 
     return filteredHabitList;
   },

--- a/src/screens/HabitListHome/WeekViewer/index.tsx
+++ b/src/screens/HabitListHome/WeekViewer/index.tsx
@@ -2,16 +2,15 @@ import React, { useRef } from 'react';
 import { View, Dimensions, ScrollView } from 'react-native';
 import { useRecoilState } from 'recoil';
 
-import DayViewer from './DayViewer';
-import YearAndMonth from './YearAndMonth';
-
 import { habitDay } from '@recoil/atoms';
 
 import { isSameDate } from '@utils';
 import { DAY_OF_THE_WEEK_LIST } from '@constants/day';
 
-import { styles } from './WeekViewer.styles';
+import DayViewer from './DayViewer';
+import YearAndMonth from './YearAndMonth';
 
+import { styles } from './WeekViewer.styles';
 import { useScrollWeeks } from './WeekViewer.hook';
 
 const { width: layoutWidth } = Dimensions.get('window');
@@ -36,7 +35,7 @@ const WeekViewer = () => {
         horizontal
         pagingEnabled
         decelerationRate="fast"
-        scrollEventThrottle={200}
+        scrollEventThrottle={20}
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={style.weekViewerScrollWrapper}
         onScrollEndDrag={changeWeekViewer}>


### PR DESCRIPTION
## 🧐 What is this PR?

- 목적 : Week viewer 가 이동할 때, 각 주의 월요일을 selected date 로 설정하는 기능을 추가한 PR 입니다.
            만약 이동한 주가 현재 주와 일치할 경우에는 오늘 날짜 기준으로 표기합니다.

- 프로덕트 기획서: [기획서](https://spangled-flyaway-82b.notion.site/7cd6ef9724134388969b0263ba0deb81)

- Figma : [figma](https://www.figma.com/file/ThUARfHpnpXxEtRGakkK2M/%EB%AA%A9%ED%91%9C-%EC%A7%80%ED%96%A5%EC%A0%81%EC%9D%B8-%EC%82%B6%EC%9D%84-%EA%BF%88%EA%BE%BC%EB%8B%A4?node-id=0%3A1)

- 기타 참고 문서 : N/A

## 💻 Changes

filteredHabitList 에 mock data 및 random 선택 기능을 추가했습니다.
이는 테스트를 위한 코드 적용입니다. 71872eb

initialTargetDate 기능을 추가했습니다. week viewer 가 이동할 경우에 호출하며,
이동한 주가 이번주일 경우엔 오늘 날짜를, 아닌 경우엔 해당 주의 월요일을 기본 선택 날짜로 설정합니다. 2f66348

## 🎥 ScreenShot or Video
https://user-images.githubusercontent.com/64253365/183299400-e65d9087-6df4-4271-b9c4-51d1130e1229.mov

## Check List
N/A
